### PR TITLE
fix: github actions 과정에서 application 주입

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Add known hosts
         run: ssh-keyscan -H ${{ secrets.SERVER_IP }} >> ~/.ssh/known_hosts
 
+      - name: application.yml 생성
+        run: echo "${{ secrets.ENV }}" > src/main/resources/application.yml
+
       # 서버 이미지 빌드 및 태그 지정
       - name: Build and tag Docker image
         run: |


### PR DESCRIPTION
close #1 

applciation.properties 제거에 따라 GitHub Actions에서 build가 실패하는 문제를 해결하기 위해
build 직전 GitHub Secrets 에 저장된 설정을 주입하도록 개선